### PR TITLE
feat: add mockup cards

### DIFF
--- a/src/scss/colors.scss
+++ b/src/scss/colors.scss
@@ -12,6 +12,7 @@ $dark-green: rgb(31,122,57);
 $yellow: rgb(250,251,62);
 $dark-yellow: rgb(199,200,4);
 $bg-info: #d9edf7;
+$light-grey: rgb(235,235,235);
 
 .text-dark-blue {
   color: $dark-blue !important;

--- a/src/scss/search.scss
+++ b/src/scss/search.scss
@@ -152,6 +152,29 @@
       }
     }
   }
+  .mockup-icon {
+    width: 20px;
+    height: 20px;
+    display: inline-block;
+    background: $light-grey;
+    border-radius: 10px;
+  }
+  .mockup-link {
+    width: 200px;
+    height: 20px;
+    display: inline-block;
+    background: rgb(235,235,255);
+  }
+  .mockup-underlink {
+    width: 400px;
+    height: 16px;
+    display: inline-block;
+    background: rgb(225,255,225);
+  }
+  .mockup-text {
+    height: 14px;
+    background: $light-grey;
+  }
 }
 
 .highlight {

--- a/src/views/partials/card-results.html
+++ b/src/views/partials/card-results.html
@@ -43,6 +43,36 @@
 
   <div class="row">
     <div class="col-md-6 results">
+      <div class="row card" ng-hide="results.groups">
+        <div class="col-xs-12">
+          <h2>
+            <span class="mockup-icon"></span>
+            <span class="mockup-link"></span>
+          </h2>
+          <p class="mockup-underlink"></p>
+          <p class="mockup-text"></p>
+        </div>
+      </div>
+      <div class="row card" ng-hide="results.groups">
+        <div class="col-xs-12">
+          <h2>
+            <span class="mockup-icon"></span>
+            <span class="mockup-link"></span>
+          </h2>
+          <p class="mockup-underlink"></p>
+          <p class="mockup-text"></p>
+        </div>
+      </div>
+      <div class="row card" ng-hide="results.groups">
+        <div class="col-xs-12">
+          <h2>
+            <span class="mockup-icon"></span>
+            <span class="mockup-link"></span>
+          </h2>
+          <p class="mockup-underlink"></p>
+          <p class="mockup-text"></p>
+        </div>
+      </div>
       <div class="row card" ng-repeat="link in results.groups track by $index" ng-mouseover="showScreenshot($index)" ng-class="{false: 'highlight'}[highlight == $index]">
         <div class="col-xs-12">
           <h2>


### PR DESCRIPTION
On web search, enter a query:
while the result are processed, you will see the mockup cards.

This is something a la LinkedIn.