### PR TITLE
fix: mockup text width is now smaller than box width

### DIFF
--- a/src/scss/search.scss
+++ b/src/scss/search.scss
@@ -160,13 +160,13 @@
     border-radius: 10px;
   }
   .mockup-link {
-    width: 200px;
+    width: 70%;
     height: 20px;
     display: inline-block;
     background: rgb(235,235,255);
   }
   .mockup-underlink {
-    width: 400px;
+    width: 90%;
     height: 16px;
     display: inline-block;
     background: rgb(225,255,225);


### PR DESCRIPTION
Do not listen to the branch's name.
It is actually fixing mockup width text.